### PR TITLE
Keep TypeScript majors out of Dependabot's reach

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,23 @@ updates:
           - "@angular-devkit/*"
           - "@angular-eslint/*"
           - "angular-eslint"
+      # Majors here are not interchangeable the way the Angular ones are, so keep them out of the
+      # group and let each arrive as its own reviewable PR.
       lint-and-types:
         patterns:
           - "eslint"
           - "typescript"
           - "typescript-eslint"
           - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # @angular/compiler-cli pins typescript to ">=6.0 <6.1", so a major TypeScript bump cannot
+      # build until Angular itself supports it. Drop this once Angular allows TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,7 @@ updates:
       # build until Angular itself supports it. Drop this once Angular allows TypeScript 7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # @types/node should track the Node we actually run (see .nvmrc), not the newest release, or
+      # the build type-checks against APIs that are not there at runtime.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/cli": "^22.1.2",
     "@angular/compiler-cli": "^22.1.0",
     "@angular/language-service": "^22.1.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^24.0.0",
     "angular-eslint": "22.1.0",
     "eslint": "^9.28.0",
     "typescript": "~6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,12 +2854,12 @@
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@^22.0.0":
-  version "22.19.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.11.tgz#7e1feaad24e4e36c52fa5558d5864bb4b272603e"
-  integrity sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==
+"@types/node@^24.0.0":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.18.0"
 
 "@types/qs@*":
   version "6.14.0"
@@ -6795,15 +6795,15 @@ typescript@6.0.3, typescript@~6.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-
 undici-types@~7.16.0:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
+
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Follow-up to #166. Dependabot's first run under the new config produced #168, which grouped **ESLint 9 → 10** with **TypeScript 6 → 7**. The TypeScript half cannot build:

- `@angular/compiler-cli` peer: `typescript: >=6.0 <6.1`
- `typescript-eslint` peer: `typescript: >=4.8.4 <6.1.0`

Two changes:

- **`lint-and-types` group restricted to minor/patch.** Unlike the Angular packages, ESLint and TypeScript are not interchangeable parts of one release train, so a major in that set should arrive alone and be judged on its own.
- **Major TypeScript bumps ignored** until Angular supports them. Worth removing once Angular allows TypeScript 7.

The `angular` group still takes majors deliberately — those packages must move together or nothing builds, which is what the original ten-PR pile-up demonstrated.

#168 should be closed; a correctly scoped ESLint 10 PR will come back on the next run.